### PR TITLE
Added tests for Saved Builds and Custom Builds for CI to run

### DIFF
--- a/src/tests/CustomBuild.test.jsx
+++ b/src/tests/CustomBuild.test.jsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import CustomBuild from '../pages/CustomBuild/CustomBuild.jsx';
+
+const mockNavigate = vi.fn();
+let mockLocationState = null; 
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+        useLocation: () => ({ state: mockLocationState }),
+    };
+});
+
+describe('CustomBuild Component', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        mockLocationState = null; 
+        vi.stubGlobal('alert', vi.fn()); 
+    });
+
+    it('renders empty component slots by default', () => {
+        render(
+            <MemoryRouter>
+                <CustomBuild />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('0 of 8 parts selected')).toBeDefined();
+        expect(screen.getByPlaceholderText('Name your custom build...').value).toBe('');
+    });
+
+    it('pre-fills data when editBuild state is passed via router location', () => {
+        mockLocationState = {
+            editBuild: {
+                id: '999',
+                name: 'Upgraded Workstation',
+                parts: { cpu: { brand: 'Intel', model: 'Core i9', price: 500 } }
+            }
+        };
+
+        render(
+            <MemoryRouter>
+                <CustomBuild />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByDisplayValue('Upgraded Workstation')).toBeDefined();
+        expect(screen.getByText('Intel Core i9')).toBeDefined();
+        expect(screen.getByText('1 of 8 parts selected')).toBeDefined();
+    });
+
+    it('triggers an alert and prevents saving if the build name is missing', () => {
+        mockLocationState = {
+            editBuild: { id: '1', name: '', parts: { cpu: { brand: 'Intel', price: 100 } } }
+        };
+
+        render(
+            <MemoryRouter>
+                <CustomBuild />
+            </MemoryRouter>
+        );
+
+        const saveBtn = screen.getByText('Save Build');
+        fireEvent.click(saveBtn);
+
+        expect(window.alert).toHaveBeenCalledWith("Please provide a name for your build.");
+        expect(mockNavigate).not.toHaveBeenCalled(); 
+    });
+
+    it('triggers an alert and prevents saving if no parts are selected', () => {
+        render(
+            <MemoryRouter>
+                <CustomBuild />
+            </MemoryRouter>
+        );
+
+        const nameInput = screen.getByPlaceholderText('Name your custom build...');
+        fireEvent.change(nameInput, { target: { value: 'Empty Build' } });
+
+        const saveBtn = screen.getByText('Save Build');
+        fireEvent.click(saveBtn);
+
+        expect(window.alert).toHaveBeenCalledWith("Please add at least one part before saving.");
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+});

--- a/src/tests/SavedBuilds.test.jsx
+++ b/src/tests/SavedBuilds.test.jsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SavedBuilds from '../pages/SavedBuilds/SavedBuilds.jsx';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    };
+});
+
+describe('SavedBuilds Component', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        vi.stubGlobal('confirm', vi.fn(() => true)); 
+    });
+
+    it('renders the empty state when no builds are saved', () => {
+        render(
+            <MemoryRouter>
+                <SavedBuilds />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText(/You haven't saved any builds yet/i)).toBeDefined();
+        expect(screen.getByRole('button', { name: /Create a Build/i })).toBeDefined();
+    });
+
+    it('renders saved builds from localStorage', () => {
+        const mockBuilds = [{
+            id: '123',
+            name: 'My Gaming Rig',
+            totalPrice: 1500,
+            dateSaved: '10/24/2025',
+            parts: { cpu: { brand: 'AMD', model: 'Ryzen 5', price: 200 } }
+        }];
+        localStorage.setItem('savedBuilds', JSON.stringify(mockBuilds));
+
+        render(
+            <MemoryRouter>
+                <SavedBuilds />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('My Gaming Rig')).toBeDefined();
+        expect(screen.getByText('$1500.00')).toBeDefined();
+        expect(screen.getByText('AMD Ryzen 5')).toBeDefined();
+    });
+
+    it('deletes a build when the delete button is clicked and confirmed', () => {
+        const mockBuilds = [{
+            id: '123',
+            name: 'Build To Delete',
+            totalPrice: 1000,
+            dateSaved: '10/24/2025',
+            parts: {}
+        }];
+        localStorage.setItem('savedBuilds', JSON.stringify(mockBuilds));
+
+        render(
+            <MemoryRouter>
+                <SavedBuilds />
+            </MemoryRouter>
+        );
+
+        const deleteBtn = screen.getByText('Delete');
+        fireEvent.click(deleteBtn);
+
+        expect(window.confirm).toHaveBeenCalledWith("Are you sure you want to delete this build?");
+        expect(JSON.parse(localStorage.getItem('savedBuilds'))).toHaveLength(0);
+        expect(screen.queryByText('Build To Delete')).toBeNull();
+    });
+
+    it('navigates to custom-build with correct state when edit is clicked', () => {
+        const mockBuild = {
+            id: '123',
+            name: 'Build To Edit',
+            totalPrice: 1000,
+            dateSaved: '10/24/2025',
+            parts: {}
+        };
+        localStorage.setItem('savedBuilds', JSON.stringify([mockBuild]));
+
+        render(
+            <MemoryRouter>
+                <SavedBuilds />
+            </MemoryRouter>
+        );
+
+        const editBtn = screen.getByText('Edit');
+        fireEvent.click(editBtn);
+
+        expect(mockNavigate).toHaveBeenCalledWith("/custom-build", { state: { editBuild: mockBuild } });
+    });
+});


### PR DESCRIPTION
Added in 8 tests total, 4 for Saved Builds and 4 for Custom Build. The tests are as follows:
Saved Builds tests(SavedBuilds.test.jsx):
- Render an empty state
- Render saved builds
- Delete a build
- Edit a build
Custom Build tests(CustomBuild.test.jsx):
- Render empty default state
- Render pre-filled state
- Trigger alert: no name
- Trigger alert: no parts
