### PR TITLE
Fix CI/CD checks, removed parallel jobs so Vercel deployment waits for tests to pass before deploying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,7 @@ jobs:
         run: npm run build
 
       - name: Run tests
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: npm run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run tests
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: npm test
         
   deploy:
+    needs: build-and-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.93.3",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
@@ -29,7 +30,6 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^28.1.0",
-    "react-router-dom": "^7.13.0",
     "vite": "^7.2.4",
     "vitest": "^4.0.18"
   }


### PR DESCRIPTION
Checks fixed:

- "CI / build (push)"
- "CD - Deploy to Vercel / build-and-test (push)"
- "CD - Deploy to Vercel / deploy (push)"
Fixes made:

- Added Supabase environment variables to Run tests in ci.yml and deploy.yml so Vitest can intialize the data from Supabase during test runs.
- Moved "react-router-dom" from devDependencies to standard dependencies.
- Added needs: build-and-test to deploy.yml so checks are ran before vercel deploys.